### PR TITLE
Fix critical MathJax XSS Vulnerability

### DIFF
--- a/public/javascripts/mathml.js
+++ b/public/javascripts/mathml.js
@@ -29,7 +29,7 @@ export function loadMathJax (configFile, cb = null) {
   if (!isMathJaxLoaded()) {
     // signal local config to mathjax as it loads
     window.MathJax = localConfig;
-    $.getScript(`//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=${configFile}`, cb);
+    $.getScript(`//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=${configFile}`, cb);
   } else if (typeof cb === 'function') {
       // Make sure we always call the callback if it is loaded already and make sure we
       // also reprocess the page since chances are if we are requesting MathJax again,


### PR DESCRIPTION
Fix a critical XSS vulnerability in MathJax due to using version 2.7.1 and not 2.7.5. This was an open and possibly exploited vulnerability that may have been exploited in any of the many schools or universities using Canvas LMS. See the full report and an example attack [here](https://github.com/Sesamestrong/example-canvas-xss-attack).